### PR TITLE
Add support for SpinalHDL 1.6.0

### DIFF
--- a/crypto/src/main/scala/spinal/crypto/construtor/SpongeCore_Std.scala
+++ b/crypto/src/main/scala/spinal/crypto/construtor/SpongeCore_Std.scala
@@ -74,7 +74,7 @@ class SpongeCore_Std(capacity: Int, rate: Int, d: Int) extends Component {
     * IO
     */
   val io = new Bundle {
-    val init   = in Bool
+    val init   = in Bool()
     val cmd    = slave(Stream(Fragment(SpongeCoreCmd_Std(rate))))
     val rsp    = master(Flow(SpongeCoreRsp_Std(d)))
     val func   = master(FuncIO_Std(b, b))

--- a/crypto/src/main/scala/spinal/crypto/hash/Hash.scala
+++ b/crypto/src/main/scala/spinal/crypto/hash/Hash.scala
@@ -73,7 +73,7 @@ case class HashCoreRsp(config: HashCoreConfig) extends Bundle {
   */
 case class HashCoreIO(config: HashCoreConfig) extends Bundle with IMasterSlave {
 
-  val init = in Bool
+  val init = in Bool()
   val cmd  = Stream(Fragment(HashCoreCmd(config)))
   val rsp  = Flow(HashCoreRsp(config))
 

--- a/crypto/src/main/scala/spinal/crypto/symmetric/twofish/TwofishCore_Std.scala
+++ b/crypto/src/main/scala/spinal/crypto/symmetric/twofish/TwofishCore_Std.scala
@@ -371,7 +371,7 @@ class TwofishRound_Std(keyWidth: Int) extends Component{
     val s                 = in  Vec(Bits(32 bits), Twofish.getWidthOfS(keyWidth))
     val key               = in  Vec(Bits(32 bits), 2)
     val dout              = out Vec(Bits(32 bits), 4)
-    val encryption        = in  Bool
+    val encryption        = in  Bool()
   }
 
   /** F operation */

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,7 +1,7 @@
 object CryptoVersion {
 
   val scalaCompiler = "2.11.6"
-  val spinal        = "1.4.0"
+  val spinal        = "1.6.0"
 
   private val version = "1.1.1"
   val tester   = s"$version"

--- a/tester/src/main/scala/cryptotest/SpinalSimLFSRTester.scala
+++ b/tester/src/main/scala/cryptotest/SpinalSimLFSRTester.scala
@@ -10,9 +10,9 @@ import scala.collection.mutable.ListBuffer
 
 
 case class LFSR_IO_TEST() extends Bundle{
-  val init  = in Bool
+  val init  = in Bool()
   val seed  = in Bits(8 bits)
-  val inc   = in Bool
+  val inc   = in Bool()
   val value = out Bits(8 bits)
 }
 

--- a/tester/src/main/scala/cryptotest/SpinalSimSpongeStdTester.scala
+++ b/tester/src/main/scala/cryptotest/SpinalSimSpongeStdTester.scala
@@ -19,7 +19,7 @@ class SpinalSimSpongeStdTester extends FunSuite {
   class FakeSponge(d: Int) extends Component {
 
     val io =  new Bundle{
-      val init   = in Bool
+      val init   = in Bool()
       val cmd    = slave(Stream(Fragment(SpongeCoreCmd_Std(576))))
       val rsp    = master(Flow(SpongeCoreRsp_Std(d)))
     }

--- a/tester/src/main/scala/play/Play_1.scala
+++ b/tester/src/main/scala/play/Play_1.scala
@@ -136,9 +136,9 @@ object PlayWithAESCore_Std{
 object PlayWithLFSR{
 
   case class LFSR_CMD() extends Bundle{
-    val init  = in Bool
+    val init  = in Bool()
     val seed  = in Bits(8 bits)
-    val inc   = in Bool
+    val inc   = in Bool()
     val value = out Bits(8 bits)
   }
 


### PR DESCRIPTION
SpinalHDL 1.6.0 requires the use of "Bool()" instead of "Bool" to create Bool signals.

This commit also sets the SpinalHDL version to 1.6.0.