### PR TITLE
build.sbt: Add root project definition

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,40 +1,22 @@
-import sbt.Keys._
-import sbt._
+// CryptoVersion is defined in project/Version.scala
 
-
-val defaultSettings = Defaults.coreDefaultSettings ++ xerial.sbt.Sonatype.sonatypeSettings ++ Seq(
+lazy val root = (project in file("."))
+  .settings(
+    name := "SpinalHDL Crypto",
     organization := "com.github.spinalhdl",
-    version      := CryptoVersion.crypto,
+    version := CryptoVersion.crypto,
     crossScalaVersions := CryptoVersion.scalaCompilers,
     scalaVersion := CryptoVersion.scalaCompilers(0),
-    fork         := true,
 
-    libraryDependencies += "org.scala-lang" % "scala-library" % scalaVersion.value,
-    libraryDependencies += compilerPlugin("com.github.spinalhdl" %% "spinalhdl-idsl-plugin" % CryptoVersion.spinal)
-  )
-
-
-lazy val crypto = (project in file("crypto"))
-  .settings(
-    defaultSettings,
-    name     := "SpinalHDL Crypto",
-    version  := CryptoVersion.crypto,
+    Compile / scalaSource := baseDirectory.value / "crypto" / "src" / "main",
+    Test / scalaSource := baseDirectory.value / "tester" / "src" / "main",
 
     libraryDependencies += "com.github.spinalhdl" %% "spinalhdl-core" % CryptoVersion.spinal,
     libraryDependencies += "com.github.spinalhdl" %% "spinalhdl-lib"  % CryptoVersion.spinal,
-
-  )
-
-
-lazy val crypto_tester = (project in file("tester"))
-  .settings(
-    defaultSettings,
-    name    := "SpinalHDL Crypto Tester",
-    version := CryptoVersion.tester,
-      
+    libraryDependencies += "org.scala-lang" % "scala-library" % scalaVersion.value,
+    libraryDependencies += compilerPlugin("com.github.spinalhdl" %% "spinalhdl-idsl-plugin" % CryptoVersion.spinal),
     libraryDependencies += "org.bouncycastle" % "bcprov-jdk15on" % "1.60",
     libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.10"
   )
-  .dependsOn(crypto)
 
-
+fork := true


### PR DESCRIPTION
I'm not sure if this is correct or I'm doing something wrong with sbt, but this is required to include this project via `dependsOn(...)`.