### PR TITLE
Update to SpinalHDL 1.7.0a

### DIFF
--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,7 +1,7 @@
 object CryptoVersion {
 
   val scalaCompilers = Seq("2.11.12", "2.12.13", "2.13.6")
-  val spinal        = "1.6.1"
+  val spinal        = "1.7.0a"
 
   private val version = "1.1.1"
   val tester   = s"$version"


### PR DESCRIPTION
Using SpinalCrypto with the original SpinalHDL version leads to strange
issues:

[info] [Progress] at 1.641 : Elaborate components
[error] Exception in thread "main" java.lang.NoSuchMethodError: 'void spinal.core.package$.assert(boolean, scala.Function0)'
[error] 	at spinal.crypto.misc.LFSR$Fibonacci$.apply(LFSR.scala:136)
[error] 	at spinal.crypto.misc.LFSR$Fibonacci$.apply(LFSR.scala:123)

Update to the latest SpinalHDL version.

Signed-off-by: Daniel Schultz <dnltz@aesc-silicon.de>